### PR TITLE
BUGFIX: env variables are now in quotes

### DIFF
--- a/Configuration/Production/Heroku/Settings.yaml
+++ b/Configuration/Production/Heroku/Settings.yaml
@@ -4,8 +4,8 @@ Neos:
     persistence:
       backendOptions:
         driver: pdo_mysql
-        dbname: %ENV_DB_NAME%
-        user: %ENV_DB_USER%
-        password: %ENV_DB_PASSWORD%
-        host: %ENV_DB_HOST%
-        port: %ENV_DB_PORT%
+        dbname: '%ENV_DB_NAME%'
+        user: '%ENV_DB_USER%'
+        password: '%ENV_DB_PASSWORD%'
+        host: '%ENV_DB_HOST%'
+        port: '%ENV_DB_PORT%'


### PR DESCRIPTION
The new yaml parser in Neos 4.0 requires the env variables to be in quotes